### PR TITLE
Improve assertEquals assertion

### DIFF
--- a/.github/workflows/test_master.yml
+++ b/.github/workflows/test_master.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
 
 jobs:
   test:

--- a/tests/unit/NestedAccessorExceptionTest.php
+++ b/tests/unit/NestedAccessorExceptionTest.php
@@ -10,15 +10,15 @@ class NestedAccessorExceptionTest extends \Codeception\Test\Unit
     public function testUnknownMode()
     {
         $e = NestedAccessorException::createAsCannotSetValue(NestedAccessor::SET_MODE_SET, 'test');
-        $this->assertEquals(NestedAccessorException::CANNOT_SET_VALUE, $e->getCode());
+        $this->assertSame(NestedAccessorException::CANNOT_SET_VALUE, $e->getCode());
 
         $e = NestedAccessorException::createAsCannotSetValue(NestedAccessor::SET_MODE_APPEND, 'test');
-        $this->assertEquals(NestedAccessorException::CANNOT_APPEND_VALUE, $e->getCode());
+        $this->assertSame(NestedAccessorException::CANNOT_APPEND_VALUE, $e->getCode());
 
         $e = NestedAccessorException::createAsCannotSetValue(NestedAccessor::SET_MODE_DELETE, 'test');
-        $this->assertEquals(NestedAccessorException::CANNOT_DELETE_VALUE, $e->getCode());
+        $this->assertSame(NestedAccessorException::CANNOT_DELETE_VALUE, $e->getCode());
 
         $e = NestedAccessorException::createAsCannotSetValue(-1, 'test');
-        $this->assertEquals(NestedAccessorException::UNKNOWN_SET_MODE, $e->getCode());
+        $this->assertSame(NestedAccessorException::UNKNOWN_SET_MODE, $e->getCode());
     }
 }

--- a/tests/unit/NestedAccessorTest.php
+++ b/tests/unit/NestedAccessorTest.php
@@ -48,54 +48,54 @@ class NestedAccessorTest extends \Codeception\Test\Unit
 
         $accessor = new NestedAccessor($input);
 
-        $this->assertEquals('Novgorod', $accessor->get('name'));
-        $this->assertEquals('Novgorod', $accessor->get(['name']));
-        $this->assertEquals('Novgorod', $accessor->get('name', true));
-        $this->assertEquals('Novgorod', $accessor->get('name', false));
+        $this->assertSame('Novgorod', $accessor->get('name'));
+        $this->assertSame('Novgorod', $accessor->get(['name']));
+        $this->assertSame('Novgorod', $accessor->get('name', true));
+        $this->assertSame('Novgorod', $accessor->get('name', false));
 
-        $this->assertEquals(null, $accessor->get('name1', false));
+        $this->assertNull($accessor->get('name1', false));
 
         try {
             $accessor->get('name1', true);
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals(NestedAccessorException::CANNOT_GET_VALUE, $e->getCode());
-            $this->assertEquals('name1', $e->getData()['path']);
-            $this->assertEquals(1, $e->getData()['count']);
+            $this->assertSame(NestedAccessorException::CANNOT_GET_VALUE, $e->getCode());
+            $this->assertSame('name1', $e->getData()['path']);
+            $this->assertSame(1, $e->getData()['count']);
         }
 
         try {
             $accessor->get('name1');
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals(NestedAccessorException::CANNOT_GET_VALUE, $e->getCode());
-            $this->assertEquals('name1', $e->getData()['path']);
-            $this->assertEquals(1, $e->getData()['count']);
+            $this->assertSame(NestedAccessorException::CANNOT_GET_VALUE, $e->getCode());
+            $this->assertSame('name1', $e->getData()['path']);
+            $this->assertSame(1, $e->getData()['count']);
         }
 
         try {
             $accessor->get('name1', true);
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals(NestedAccessorException::CANNOT_GET_VALUE, $e->getCode());
-            $this->assertEquals('name1', $e->getData()['path']);
-            $this->assertEquals(1, $e->getData()['count']);
+            $this->assertSame(NestedAccessorException::CANNOT_GET_VALUE, $e->getCode());
+            $this->assertSame('name1', $e->getData()['path']);
+            $this->assertSame(1, $e->getData()['count']);
         }
 
-        $this->assertEquals(null, $accessor->get('status'));
-        $this->assertEquals(null, $accessor->get('status', true));
-        $this->assertEquals(null, $accessor->get('status', false));
+        $this->assertNull($accessor->get('status'));
+        $this->assertNull($accessor->get('status', true));
+        $this->assertNull($accessor->get('status', false));
 
-        $this->assertEquals('Moscow', $accessor->get('country.capitals.msk'));
-        $this->assertEquals('Moscow', $accessor->get(['country', 'capitals', 'msk']));
-        $this->assertEquals(null, $accessor->get('country.capitals.msk1', false));
+        $this->assertSame('Moscow', $accessor->get('country.capitals.msk'));
+        $this->assertSame('Moscow', $accessor->get(['country', 'capitals', 'msk']));
+        $this->assertNull($accessor->get('country.capitals.msk1', false));
         try {
             $accessor->get('country.capitals.msk1');
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals(NestedAccessorException::CANNOT_GET_VALUE, $e->getCode());
-            $this->assertEquals('country.capitals.msk1', $e->getData()['path']);
-            $this->assertEquals(1, $e->getData()['count']);
+            $this->assertSame(NestedAccessorException::CANNOT_GET_VALUE, $e->getCode());
+            $this->assertSame('country.capitals.msk1', $e->getData()['path']);
+            $this->assertSame(1, $e->getData()['count']);
         }
     }
 
@@ -147,7 +147,7 @@ class NestedAccessorTest extends \Codeception\Test\Unit
         };
 
         $accessor = new NestedAccessor($source);
-        $this->assertEquals(-5, $accessor->get('myProp'));
+        $this->assertSame(-5, $accessor->get('myProp'));
 
         $source = new class(5) {
             protected int $myProp;
@@ -168,7 +168,7 @@ class NestedAccessorTest extends \Codeception\Test\Unit
             $accessor->get('myProp');
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals("cannot get value by path 'myProp'", $e->getMessage());
+            $this->assertSame("cannot get value by path 'myProp'", $e->getMessage());
         }
 
         $source = new class(5) {
@@ -190,7 +190,7 @@ class NestedAccessorTest extends \Codeception\Test\Unit
             $accessor->get('myProp');
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals("cannot get value by path 'myProp'", $e->getMessage());
+            $this->assertSame("cannot get value by path 'myProp'", $e->getMessage());
         }
     }
 
@@ -206,7 +206,7 @@ class NestedAccessorTest extends \Codeception\Test\Unit
         };
 
         $accessor = new NestedAccessor($source);
-        $this->assertEquals(10, $accessor->get('a'));
+        $this->assertSame(10, $accessor->get('a'));
 
         $source = new class (10) {
             public int $a;
@@ -223,7 +223,7 @@ class NestedAccessorTest extends \Codeception\Test\Unit
         };
 
         $accessor = new NestedAccessor($source);
-        $this->assertEquals(10, $accessor->get('a'));
+        $this->assertSame(10, $accessor->get('a'));
 
         $source = new class (10) {
             protected int $a;
@@ -239,7 +239,7 @@ class NestedAccessorTest extends \Codeception\Test\Unit
             $accessor->get('a');
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals("cannot get value by path 'a'", $e->getMessage());
+            $this->assertSame("cannot get value by path 'a'", $e->getMessage());
         }
 
         $source = new class (10) {
@@ -256,7 +256,7 @@ class NestedAccessorTest extends \Codeception\Test\Unit
             $accessor->get('a');
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals("cannot get value by path 'a'", $e->getMessage());
+            $this->assertSame("cannot get value by path 'a'", $e->getMessage());
         }
     }
 
@@ -403,9 +403,9 @@ class NestedAccessorTest extends \Codeception\Test\Unit
             $accessor->get('countries.cities.extra.codes.value');
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals(NestedAccessorException::CANNOT_GET_VALUE, $e->getCode());
-            $this->assertEquals('countries.cities.extra.codes.value', $e->getData()['path']);
-            $this->assertEquals(3, $e->getData()['count']);
+            $this->assertSame(NestedAccessorException::CANNOT_GET_VALUE, $e->getCode());
+            $this->assertSame('countries.cities.extra.codes.value', $e->getData()['path']);
+            $this->assertSame(3, $e->getData()['count']);
         }
     }
 
@@ -466,10 +466,10 @@ class NestedAccessorTest extends \Codeception\Test\Unit
             ]
         ];
         $accessor = new NestedAccessor($input);
-        $this->assertEquals(1, $accessor->get('a'));
+        $this->assertSame(1, $accessor->get('a'));
         $this->assertEquals((object)['c' => 2], $accessor->get('b'));
-        $this->assertEquals(null, $accessor->get('c', false));
-        $this->assertEquals(null, $accessor->get('c.d.e', false));
+        $this->assertNull($accessor->get('c', false));
+        $this->assertNull($accessor->get('c.d.e', false));
     }
 
     /**
@@ -489,23 +489,23 @@ class NestedAccessorTest extends \Codeception\Test\Unit
         $accessor->set('test.b.a', 33);
         $this->assertEquals(['a' => 33], $accessor->get('test.b'));
         $accessor->set('test.b.c', ['d' => 'e']);
-        $this->assertEquals('e', $accessor->get('test.b.c.d'));
+        $this->assertSame('e', $accessor->get('test.b.c.d'));
         $accessor->set('test.b', 0);
-        $this->assertEquals(0, $accessor->get('test.b'));
-        $this->assertEquals(null, $accessor->get('test.b.c.d', false));
+        $this->assertSame(0, $accessor->get('test.b'));
+        $this->assertNull($accessor->get('test.b.c.d', false));
         $accessor->set('test.b.c', (object)['d' => 'e']);
         $this->assertEquals((object)['d' => 'e'], $accessor->get('test.b.c', false));
         $accessor->set('test.b.c.f', 123);
-        $this->assertEquals(123, $accessor->get('test.b.c.f'));
+        $this->assertSame(123, $accessor->get('test.b.c.f'));
 
-        $this->assertEquals('e', $accessor->get('test.b.c.d'));
+        $this->assertSame('e', $accessor->get('test.b.c.d'));
         $accessor->set('test.b.c.f', 123, false);
-        $this->assertEquals(123, $accessor->get('test.b.c.f'));
+        $this->assertSame(123, $accessor->get('test.b.c.f'));
         $this->assertEquals(['a' => 1, 'b' => 2], $accessor->get('test.a'));
 
         $input = ['a' => 1];
         $accessor = new NestedAccessor($input);
-        $this->assertEquals(1, $accessor->get('a'));
+        $this->assertSame(1, $accessor->get('a'));
         $this->assertEquals(['a' => 1], $accessor->get());
         $this->assertEquals(['a' => 1], $accessor->get(''));
         $accessor->set('a.b', 22);
@@ -516,7 +516,7 @@ class NestedAccessorTest extends \Codeception\Test\Unit
         $input = ['test' => (object)[]];
         $accessor = new NestedAccessor($input);
         $accessor->set('test.a', 123);
-        $this->assertEquals(123, $accessor->get('test.a'));
+        $this->assertSame(123, $accessor->get('test.a'));
 
         $input = ['test' => new class (10) {
             public int $a;
@@ -528,14 +528,14 @@ class NestedAccessorTest extends \Codeception\Test\Unit
         }];
         $accessor = new NestedAccessor($input);
         $accessor->set('test.a', 123);
-        $this->assertEquals(123, $accessor->get('test.a'));
+        $this->assertSame(123, $accessor->get('test.a'));
 
         try {
             $accessor->set('test.b', 123);
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals(NestedAccessorException::CANNOT_SET_VALUE, $e->getCode());
-            $this->assertEquals('test.b', $e->getData()['path']);
+            $this->assertSame(NestedAccessorException::CANNOT_SET_VALUE, $e->getCode());
+            $this->assertSame('test.b', $e->getData()['path']);
         }
     }
 
@@ -546,8 +546,8 @@ class NestedAccessorTest extends \Codeception\Test\Unit
             new NestedAccessor($input);
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals(NestedAccessorException::SOURCE_IS_SCALAR, $e->getCode());
-            $this->assertEquals('integer', $e->getData()['source_type']);
+            $this->assertSame(NestedAccessorException::SOURCE_IS_SCALAR, $e->getCode());
+            $this->assertSame('integer', $e->getData()['source_type']);
         }
 
         $input = 123.5;
@@ -555,8 +555,8 @@ class NestedAccessorTest extends \Codeception\Test\Unit
             new NestedAccessor($input);
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals(NestedAccessorException::SOURCE_IS_SCALAR, $e->getCode());
-            $this->assertEquals('double', $e->getData()['source_type']);
+            $this->assertSame(NestedAccessorException::SOURCE_IS_SCALAR, $e->getCode());
+            $this->assertSame('double', $e->getData()['source_type']);
         }
 
         $input = 'str';
@@ -564,8 +564,8 @@ class NestedAccessorTest extends \Codeception\Test\Unit
             new NestedAccessor($input);
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals(NestedAccessorException::SOURCE_IS_SCALAR, $e->getCode());
-            $this->assertEquals('string', $e->getData()['source_type']);
+            $this->assertSame(NestedAccessorException::SOURCE_IS_SCALAR, $e->getCode());
+            $this->assertSame('string', $e->getData()['source_type']);
         }
 
         $input = true;
@@ -573,8 +573,8 @@ class NestedAccessorTest extends \Codeception\Test\Unit
             new NestedAccessor($input);
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals(NestedAccessorException::SOURCE_IS_SCALAR, $e->getCode());
-            $this->assertEquals('boolean', $e->getData()['source_type']);
+            $this->assertSame(NestedAccessorException::SOURCE_IS_SCALAR, $e->getCode());
+            $this->assertSame('boolean', $e->getData()['source_type']);
         }
     }
 
@@ -601,8 +601,8 @@ class NestedAccessorTest extends \Codeception\Test\Unit
             $na->append('ass_array', 11);
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals(NestedAccessorException::CANNOT_APPEND_VALUE, $e->getCode());
-            $this->assertEquals('ass_array', $e->getData()['path']);
+            $this->assertSame(NestedAccessorException::CANNOT_APPEND_VALUE, $e->getCode());
+            $this->assertSame('ass_array', $e->getData()['path']);
         }
 
         $na->append('ass_array', 11, false);
@@ -612,8 +612,8 @@ class NestedAccessorTest extends \Codeception\Test\Unit
             $na->append('scalar', 33);
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals(NestedAccessorException::CANNOT_APPEND_VALUE, $e->getCode());
-            $this->assertEquals('scalar', $e->getData()['path']);
+            $this->assertSame(NestedAccessorException::CANNOT_APPEND_VALUE, $e->getCode());
+            $this->assertSame('scalar', $e->getData()['path']);
         }
 
         $na->append('scalar', 22, false);
@@ -637,8 +637,8 @@ class NestedAccessorTest extends \Codeception\Test\Unit
             $na->append('a.b.c', 6);
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals(NestedAccessorException::CANNOT_APPEND_VALUE, $e->getCode());
-            $this->assertEquals('a.b.c', $e->getData()['path']);
+            $this->assertSame(NestedAccessorException::CANNOT_APPEND_VALUE, $e->getCode());
+            $this->assertSame('a.b.c', $e->getData()['path']);
         }
 
         $na->append('a.b.c', 6, false);
@@ -671,8 +671,8 @@ class NestedAccessorTest extends \Codeception\Test\Unit
             $na->delete('test');
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals(NestedAccessorException::CANNOT_DELETE_VALUE, $e->getCode());
-            $this->assertEquals('test', $e->getData()['path']);
+            $this->assertSame(NestedAccessorException::CANNOT_DELETE_VALUE, $e->getCode());
+            $this->assertSame('test', $e->getData()['path']);
         }
         $this->assertEquals(['null' => 3], $na->get(''));
 
@@ -712,16 +712,16 @@ class NestedAccessorTest extends \Codeception\Test\Unit
             $na->delete('test.a');
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals(NestedAccessorException::CANNOT_DELETE_VALUE, $e->getCode());
-            $this->assertEquals('test.a', $e->getData()['path']);
+            $this->assertSame(NestedAccessorException::CANNOT_DELETE_VALUE, $e->getCode());
+            $this->assertSame('test.a', $e->getData()['path']);
         }
 
         try {
             $na->delete('test.b');
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals(NestedAccessorException::CANNOT_DELETE_VALUE, $e->getCode());
-            $this->assertEquals('test.b', $e->getData()['path']);
+            $this->assertSame(NestedAccessorException::CANNOT_DELETE_VALUE, $e->getCode());
+            $this->assertSame('test.b', $e->getData()['path']);
         }
     }
 

--- a/tests/unit/NestedFactoryTest.php
+++ b/tests/unit/NestedFactoryTest.php
@@ -16,14 +16,14 @@ class NestedFactoryTest extends \Codeception\Test\Unit
     {
         $sourceArray = ['test' => 1];
         $na = NestedAccessorFactory::create($sourceArray);
-        $this->assertEquals(1, $na->get('test'));
+        $this->assertSame(1, $na->get('test'));
 
         $na = NestedAccessorFactory::fromArray($sourceArray);
-        $this->assertEquals(1, $na->get('test'));
+        $this->assertSame(1, $na->get('test'));
 
         $sourceObject = (object)$sourceArray;
         $na = NestedAccessorFactory::fromObject($sourceObject);
-        $this->assertEquals(1, $na->get('test'));
+        $this->assertSame(1, $na->get('test'));
     }
 
     /**
@@ -34,13 +34,13 @@ class NestedFactoryTest extends \Codeception\Test\Unit
     {
         $sourceArray = ['test' => 1];
         $na = SilentNestedAccessorFactory::create($sourceArray);
-        $this->assertEquals(1, $na->get('test'));
+        $this->assertSame(1, $na->get('test'));
 
         $na = SilentNestedAccessorFactory::fromArray($sourceArray);
-        $this->assertEquals(1, $na->get('test'));
+        $this->assertSame(1, $na->get('test'));
 
         $sourceObject = (object)$sourceArray;
         $na = SilentNestedAccessorFactory::fromObject($sourceObject);
-        $this->assertEquals(1, $na->get('test'));
+        $this->assertSame(1, $na->get('test'));
     }
 }

--- a/tests/unit/NestedHelperTest.php
+++ b/tests/unit/NestedHelperTest.php
@@ -19,14 +19,14 @@ class NestedHelperTest extends \Codeception\Test\Unit
         $this->assertEquals([1, 2], NestedAccess::get($source, ['a', 'b', 'c']));
         NestedAccess::set($source, ['a', 'd'], 22);
         $this->assertEquals([1, 2], NestedAccess::get($source, ['a', 'b', 'c']));
-        $this->assertEquals(22, NestedAccess::get($source, ['a', 'd']));
+        $this->assertSame(22, NestedAccess::get($source, ['a', 'd']));
 
         $source = [
             'test' => ['value' => 123],
         ];
-        $this->assertEquals(123, NestedAccess::get($source, ['test', 'value']));
-        $this->assertEquals(123, NestedAccess::get($source, 'test.value'));
-        $this->assertEquals(null, NestedAccess::get($source, 'unknown.value', false));
+        $this->assertSame(123, NestedAccess::get($source, ['test', 'value']));
+        $this->assertSame(123, NestedAccess::get($source, 'test.value'));
+        $this->assertNull(NestedAccess::get($source, 'unknown.value', false));
 
         $source = ['test' => [1, 2]];
         NestedAccess::append($source, ['test'], 3);
@@ -96,8 +96,8 @@ class NestedHelperTest extends \Codeception\Test\Unit
             NestedAccess::delete($source, 'test');
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals(NestedAccessorException::CANNOT_DELETE_VALUE, $e->getCode());
-            $this->assertEquals('test', $e->getData()['path']);
+            $this->assertSame(NestedAccessorException::CANNOT_DELETE_VALUE, $e->getCode());
+            $this->assertSame('test', $e->getData()['path']);
         }
         $this->assertEquals(['null' => 3], NestedAccess::get($source, ''));
 

--- a/tests/unit/NestedStorageTest.php
+++ b/tests/unit/NestedStorageTest.php
@@ -19,7 +19,7 @@ class NestedStorageTest extends \Codeception\Test\Unit
         $this->assertEquals([1, 2], $ns->get(['a', 'b', 'c']));
         $ns->set(['a', 'd'], 22);
         $this->assertEquals([1, 2], $ns->get(['a', 'b', 'c']));
-        $this->assertEquals(22, $ns->get(['a', 'd']));
+        $this->assertSame(22, $ns->get(['a', 'd']));
 
         $ns = new NestedArrayStorage(['test' => [1, 2]]);
         $ns->append('test', 3);
@@ -89,8 +89,8 @@ class NestedStorageTest extends \Codeception\Test\Unit
             $na->delete('test');
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals(NestedAccessorException::CANNOT_DELETE_VALUE, $e->getCode());
-            $this->assertEquals('test', $e->getData()['path']);
+            $this->assertSame(NestedAccessorException::CANNOT_DELETE_VALUE, $e->getCode());
+            $this->assertSame('test', $e->getData()['path']);
         }
         $this->assertEquals(['null' => 3], $na->get(''));
 

--- a/tests/unit/SilentNestedAccessorTest.php
+++ b/tests/unit/SilentNestedAccessorTest.php
@@ -48,11 +48,10 @@ class SilentNestedAccessorTest extends \Codeception\Test\Unit
 
         $accessor = new SilentNestedAccessor($input);
 
-        $this->assertEquals('Novgorod', $accessor->get('name'));
-        $this->assertEquals('Novgorod', $accessor->get(['name']));
-        $this->assertEquals('Novgorod', $accessor->get('name'));
-        $this->assertEquals(null, $accessor->get('status'));
-        $this->assertEquals(null, $accessor->get('name1'));
+        $this->assertSame('Novgorod', $accessor->get('name'));
+        $this->assertSame('Novgorod', $accessor->get(['name']));
+        $this->assertNull($accessor->get('status'));
+        $this->assertNull($accessor->get('name1'));
     }
 
     /**
@@ -72,24 +71,24 @@ class SilentNestedAccessorTest extends \Codeception\Test\Unit
         $accessor->set('test.b.a', 33);
         $this->assertEquals(['a' => 33], $accessor->get('test.b'));
         $accessor->set('test.b.c', ['d' => 'e']);
-        $this->assertEquals('e', $accessor->get('test.b.c.d'));
+        $this->assertSame('e', $accessor->get('test.b.c.d'));
         $accessor->set('test.b', 0);
-        $this->assertEquals(0, $accessor->get('test.b'));
-        $this->assertEquals(null, $accessor->get('test.b.c.d', false));
+        $this->assertSame(0, $accessor->get('test.b'));
+        $this->assertNull($accessor->get('test.b.c.d', false));
         $accessor->set('test.b.c', (object)['d' => 'e']);
         $this->assertEquals((object)['d' => 'e'], $accessor->get('test.b.c', false));
 
         // silent skip
         $accessor->set('test.b.c.f', 123);
 
-        $this->assertEquals('e', $accessor->get('test.b.c.d'));
+        $this->assertSame('e', $accessor->get('test.b.c.d'));
         $accessor->set('test.b.c.f', 123, false);
-        $this->assertEquals(123, $accessor->get('test.b.c.f'));
+        $this->assertSame(123, $accessor->get('test.b.c.f'));
         $this->assertEquals(['a' => 1, 'b' => 2], $accessor->get('test.a'));
 
         $input = ['a' => 1];
         $accessor = new SilentNestedAccessor($input);
-        $this->assertEquals(1, $accessor->get('a'));
+        $this->assertSame(1, $accessor->get('a'));
         $this->assertEquals(['a' => 1], $accessor->get());
         $this->assertEquals(['a' => 1], $accessor->get(''));
         $accessor->set('a.b', 22);
@@ -105,8 +104,8 @@ class SilentNestedAccessorTest extends \Codeception\Test\Unit
             new SilentNestedAccessor($input);
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals(NestedAccessorException::SOURCE_IS_SCALAR, $e->getCode());
-            $this->assertEquals('integer', $e->getData()['source_type']);
+            $this->assertSame(NestedAccessorException::SOURCE_IS_SCALAR, $e->getCode());
+            $this->assertSame('integer', $e->getData()['source_type']);
         }
 
         $input = 123.5;
@@ -114,8 +113,8 @@ class SilentNestedAccessorTest extends \Codeception\Test\Unit
             new SilentNestedAccessor($input);
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals(NestedAccessorException::SOURCE_IS_SCALAR, $e->getCode());
-            $this->assertEquals('double', $e->getData()['source_type']);
+            $this->assertSame(NestedAccessorException::SOURCE_IS_SCALAR, $e->getCode());
+            $this->assertSame('double', $e->getData()['source_type']);
         }
 
         $input = 'str';
@@ -123,8 +122,8 @@ class SilentNestedAccessorTest extends \Codeception\Test\Unit
             new SilentNestedAccessor($input);
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals(NestedAccessorException::SOURCE_IS_SCALAR, $e->getCode());
-            $this->assertEquals('string', $e->getData()['source_type']);
+            $this->assertSame(NestedAccessorException::SOURCE_IS_SCALAR, $e->getCode());
+            $this->assertSame('string', $e->getData()['source_type']);
         }
 
         $input = true;
@@ -132,8 +131,8 @@ class SilentNestedAccessorTest extends \Codeception\Test\Unit
             new SilentNestedAccessor($input);
             $this->fail();
         } catch(NestedAccessorException $e) {
-            $this->assertEquals(NestedAccessorException::SOURCE_IS_SCALAR, $e->getCode());
-            $this->assertEquals('boolean', $e->getData()['source_type']);
+            $this->assertSame(NestedAccessorException::SOURCE_IS_SCALAR, $e->getCode());
+            $this->assertSame('boolean', $e->getData()['source_type']);
         }
     }
 
@@ -238,7 +237,7 @@ class SilentNestedAccessorTest extends \Codeception\Test\Unit
         $na->delete('test.a');
         $na->delete('test.b');
 
-        $this->assertEquals(10, $source['test']->a);
+        $this->assertSame(10, $source['test']->a);
     }
 
     /**


### PR DESCRIPTION
# Changed log

- Using the `assertSame` to make assert equals strict.
- Using the `assertNull` to let assert equals be null.
- Remove master only in the PR trigger.